### PR TITLE
fixed sscep crash in verbose mode trying to access a nullPtr

### DIFF
--- a/engine.c
+++ b/engine.c
@@ -162,10 +162,10 @@ ENGINE *scep_engine_load_dynamic(ENGINE *e) {
 void sscep_engine_read_key(EVP_PKEY **key, char *id, ENGINE *e) {
 	*key = ENGINE_load_private_key(e, id, NULL, NULL);
 	//ERR_print_errors_fp(stderr);
-	
+
 	if(*key == 0) {
 		if(v_flag)
-			printf("%s: Pivate key %s could not be loaded via engine %s, trying file load\n", pname, id, scep_conf->engine->engine_id);
+			printf("%s: Pivate key %s could not be loaded via engine, trying file load\n", pname);
 		read_key(key, id);
 		if(*key != 0)
 			printf("%s: Found private key %s as file. If the engine can handle it, loading the file\n", pname, id);

--- a/fileutils.c
+++ b/fileutils.c
@@ -157,7 +157,7 @@ write_local_cert(struct scep *s) {
 		exit (SCEP_PKISTATUS_FILE);
 	}
 	if (v_flag)
-		printf("%s: writing cert\n", pname);
+		printf("%s: certificate written as %s\n", pname, l_char);
 	if (d_flag)
 		PEM_write_X509(stdout, localcert);
 	if (PEM_write_X509(fp, localcert) != 1) {
@@ -166,7 +166,6 @@ write_local_cert(struct scep *s) {
 		ERR_print_errors_fp(stderr);
 		exit (SCEP_PKISTATUS_FILE);
 	}
-	printf("%s: certificate written as %s\n", pname, l_char);
 	(void)fclose(fp);
 }
 
@@ -223,7 +222,7 @@ write_other_cert(struct scep *s) {
 		exit (SCEP_PKISTATUS_FILE);
 	}
 	if (v_flag)
-		printf("%s: writing cert\n", pname);
+		printf("%s: certificate written as %s\n", pname, w_char);
 	if (d_flag)
 		PEM_write_X509(stdout, othercert);
 	if (PEM_write_X509(fp, othercert) != 1) {
@@ -232,7 +231,6 @@ write_other_cert(struct scep *s) {
 		ERR_print_errors_fp(stderr);
 		exit (SCEP_PKISTATUS_FILE);
 	}
-	printf("%s: certificate written as %s\n", pname, w_char);
 	(void)fclose(fp);
 }
 
@@ -292,9 +290,12 @@ write_ca_ra(struct http_reply *s) {
 		snprintf(name, 1024, "%s-%d", c_char, i);
 
 		/* Read and print certificate information */
+		if (v_flag){
 		printf("\n%s: found certificate with\n  subject: %s\n", pname,
 		X509_NAME_oneline(X509_get_subject_name(cert),
 					buffer, sizeof(buffer)));
+		}
+		if (v_flag)
 		printf("  issuer: %s\n", 
 			X509_NAME_oneline(X509_get_issuer_name(cert),
 					buffer, sizeof(buffer)));
@@ -311,14 +312,17 @@ write_ca_ra(struct http_reply *s) {
 			/* exit (SCEP_PKISTATUS_FILE); */
 		} else {
 			ext = X509_get_ext(cert, index);
-			printf("  usage: ");
-			X509V3_EXT_print_fp(stdout, ext, 0, 0);
-			printf("\n");
+			if (v_flag){
+				printf("  usage: ");
+				X509V3_EXT_print_fp(stdout, ext, 0, 0);
+				printf("\n");
+			}
 		}
-
-		printf("  %s fingerprint: ", OBJ_nid2sn(EVP_MD_type(fp_alg)));
-		for (c = 0; c < (int)n; c++) {
-			printf("%02X%c",md[c], (c + 1 == (int)n) ?'\n':':');
+		if (v_flag){
+			printf("  %s fingerprint: ", OBJ_nid2sn(EVP_MD_type(fp_alg)));
+			for (c = 0; c < (int)n; c++) {
+				printf("%02X%c",md[c], (c + 1 == (int)n) ?'\n':':');
+			}
 		}
 
 		/* Write PEM-formatted file: */
@@ -333,7 +337,7 @@ write_ca_ra(struct http_reply *s) {
 			exit (SCEP_PKISTATUS_FILE);
 		}
 		if (v_flag)
-			printf("%s: writing cert\n", pname);
+			printf("%s: certificate written as %s\n", pname, name);
 		if (d_flag)
 			PEM_write_X509(stdout, cert);
 		if (PEM_write_X509(fp, cert) != 1) {
@@ -342,7 +346,7 @@ write_ca_ra(struct http_reply *s) {
 			ERR_print_errors_fp(stderr);
 			exit (SCEP_PKISTATUS_FILE);
 		}
-		printf("%s: certificate written as %s\n", pname, name);
+
 	}
 	(void)fclose(fp);
 	exit (SCEP_PKISTATUS_SUCCESS);

--- a/pkcs7.c
+++ b/pkcs7.c
@@ -478,6 +478,7 @@ int pkcs7_verify_unwrap(struct scep *s , char * cachainfile ) {
 			ERR_print_errors_fp(stderr);
 			exit (SCEP_PKISTATUS_FILE);
 		}else{
+			if(v_flag)
 			printf("%s: certificate written as %s\n", pname, w_char);
 		}
 

--- a/sscep.c
+++ b/sscep.c
@@ -87,7 +87,7 @@ main(int argc, char **argv) {
 	WSADATA wsaData;
 	int err;
 	//printf("Starting sscep\n");
-	fprintf(stdout, "%s: starting sscep on WIN32, sscep version %s\n",	pname, VERSION);
+	//fprintf(stdout, "%s: starting sscep on WIN32, sscep version %s\n",	pname, VERSION);
        
 	wVersionRequested = MAKEWORD( 2, 2 );
  
@@ -528,10 +528,13 @@ main(int argc, char **argv) {
 			}
 
 
-			printf("%s: requesting CA certificate\n", pname);
-			if (d_flag)
+
+			if (d_flag){
+				printf("%s: requesting CA certificate\n", pname);
 				fprintf(stdout, "%s: scep msg: %s", pname,
-					http_string);
+									http_string);
+			}
+
 			/*
 			 * Send http message.
 			 * Response is written to http_response struct "reply".
@@ -548,7 +551,9 @@ main(int argc, char **argv) {
 				   "should define CA identifier (-i)\n", pname);
 				exit (SCEP_PKISTATUS_SUCCESS);
 			}
-			printf("%s: valid response from server\n", pname);
+			if (v_flag){
+				printf("%s: valid response from server\n", pname);
+			}
 			if (reply.type == SCEP_MIME_GETCA_RA) {
 				/* XXXXXXXXXXXXXXXXXXXXX chain not verified */
 				write_ca_ra(&reply);
@@ -562,11 +567,14 @@ main(int argc, char **argv) {
 				ERR_print_errors_fp(stderr);
 				exit (SCEP_PKISTATUS_ERROR);
 			}
-			printf("%s: %s fingerprint: ", pname,
-				OBJ_nid2sn(EVP_MD_type(fp_alg)));
-			for (c = 0; c < (int)n; c++) {
-				printf("%02X%c",md[c],
-					(c + 1 == (int)n) ?'\n':':');
+			if (v_flag){
+				printf("%s: %s fingerprint: ", pname,
+					OBJ_nid2sn(EVP_MD_type(fp_alg)));
+				for (c = 0; c < (int)n; c++) {
+					printf("%02X%c",md[c],
+						(c + 1 == (int)n) ?'\n':':');
+				}
+
 			}
 
 			/* Write PEM-formatted file: */
@@ -586,6 +594,7 @@ main(int argc, char **argv) {
 				ERR_print_errors_fp(stderr);
 				exit (SCEP_PKISTATUS_ERROR);
 			}
+			if (v_flag)
 			printf("%s: CA certificate written as %s\n",
 				pname, c_char);
 			(void)fclose(fp);
@@ -615,11 +624,14 @@ main(int argc, char **argv) {
 							i_char, M_char);
 
 				}
-				printf("%s: requesting nextCA certificate\n", pname);
 
-				if (d_flag)
+
+				if (d_flag){
+					printf("%s: requesting nextCA certificate\n", pname);
 					fprintf(stdout, "%s: scep msg: %s", pname,
 						http_string);
+				}
+
 				/*
 				 * Send http message.
 				 * Response is written to http_response struct "reply".
@@ -639,6 +651,7 @@ main(int argc, char **argv) {
 					exit (SCEP_PKISTATUS_SUCCESS);
 				}
 
+				if(d_flag)
 				printf("%s: valid response from server\n", pname);
 
 				if (reply.type == SCEP_MIME_GETNEXTCA) {
@@ -704,6 +717,7 @@ main(int argc, char **argv) {
 			    			ERR_print_errors_fp(stderr);
 			    			exit (SCEP_PKISTATUS_FILE);
 			    		}
+			    		if(v_flag)
 			    		printf("%s: certificate written as %s\n", pname, name);
 			    		(void)fclose(fp);
 			    }
@@ -727,6 +741,7 @@ main(int argc, char **argv) {
 			 * Read in CA cert, private key and certificate
 			 * request in global variables.
 			 */
+
 		        read_ca_cert();
 
 			if (!k_flag) {
@@ -739,6 +754,7 @@ main(int argc, char **argv) {
 			} else {
 				read_key(&rsa, k_char);
 			}
+
 
 			if ((K_flag && !O_flag) || (!K_flag && O_flag)) {
 			  fprintf(stderr, "%s: -O also requires -K (and vice-versa)\n", pname);


### PR DESCRIPTION
fixed log messages in multiple locations to only be executed in verbose or debug mode
fixed sscep crash in verbose mode trying to access a nullPtr in configfile parsing
