### PR TITLE
included transaction id to always be printed on stdout during enrollment...

### DIFF
--- a/net.c
+++ b/net.c
@@ -197,6 +197,7 @@ send_msg(struct http_reply *http,char *msg,char *host,int port,int operation) {
 	return (0);
 
 mime_err:
+if (v_flag)
 	fprintf(stderr, "%s: wrong (or missing) MIME content type\n", pname);
 	return (1);
 

--- a/pkcs7.c
+++ b/pkcs7.c
@@ -597,7 +597,7 @@ int pkcs7_unwrap(struct scep *s) {
 		fprintf(stderr, "%s: cannot find transId\n", pname);
 		exit (SCEP_PKISTATUS_P7);
 	}
-	if (v_flag)
+//	if (v_flag)
 		printf("%s: reply transaction id: %s\n", pname, p);
 	if (strncmp(s->transaction_id, p, strlen(p))) {
 		fprintf(stderr, "%s: transaction id mismatch\n", pname);

--- a/sscep.c
+++ b/sscep.c
@@ -639,10 +639,12 @@ main(int argc, char **argv) {
 				reply.payload = NULL;
 				if ((c = send_msg (&reply, http_string, host_name,
 						host_port, operation_flag)) == 1) {
+					if(v_flag){
 					fprintf(stderr, "%s: error while sending "
 						"message\n", pname);
 					fprintf(stderr, "%s: getnextCA might be not available"
 											"\n", pname);
+					}
 					exit (SCEP_PKISTATUS_NET);
 				}
 				if (reply.payload == NULL) {


### PR DESCRIPTION
included transaction id to always be printed on stdout during enrollment
removed stdout messages when getnextca is not available
