### PR TITLE
Create separate RPM packages for static and dynamic versions of sscep

### DIFF
--- a/Linux/make_Linux_package.sh
+++ b/Linux/make_Linux_package.sh
@@ -4,7 +4,10 @@ echo "Creating package..."
 #arch=$(uname -p)
 #ts=$(date +'%Y%m%d%H%M%S')
 version=$(head -n 1 VERSION)
-sed "s/VERSIONINFO/$version/" < Linux/sscep.spec.in > Linux/sscep.spec
-tar --transform "s/^\./sscep-$version/" --exclude '.git' -czf $HOME/rpmbuild/SOURCES/sscep-$version.tar.gz .
-rpmbuild -bb Linux/sscep.spec
+sed "s/VERSIONINFO/$version/" < Linux/sscep-static.spec.in > Linux/sscep-static.spec
+tar --transform "s/^\./sscep-static-$version/" --exclude '.git' -czf $HOME/rpmbuild/SOURCES/sscep-static-$version.tar.gz .
+rpmbuild -bb Linux/sscep-static.spec
+sed "s/VERSIONINFO/$version/" < Linux/sscep-dyn.spec.in > Linux/sscep-dyn.spec
+tar --transform "s/^\./sscep-dyn-$version/" --exclude '.git' -czf $HOME/rpmbuild/SOURCES/sscep-dyn-$version.tar.gz .
+rpmbuild -bb Linux/sscep-dyn.spec
 

--- a/Linux/sscep-dyn.spec.in
+++ b/Linux/sscep-dyn.spec.in
@@ -2,7 +2,7 @@
 # SSCEP spec file 
 # 
 
-Name:         sscep 
+Name:         sscep-dyn
 License:      GPL 
 Group:        Productivity/Security 
 Autoreqprov:  on 
@@ -25,11 +25,10 @@ make
 %install 
 mkdir -p $RPM_BUILD_ROOT 
 install -D -m 755 sscep_dyn $RPM_BUILD_ROOT/opt/CertNanny/bin/sscep_dyn 
-install -D -m 755 sscep_static $RPM_BUILD_ROOT/opt/CertNanny/bin/sscep_static 
 install -D -m 644 COPYRIGHT $RPM_BUILD_ROOT/opt/CertNanny/COPYRIGHT.sscep
 /bin/ln -fs sscep_static $RPM_BUILD_ROOT/opt/CertNanny/bin/sscep 
 mkdir -p $RPM_BUILD_ROOT/usr/bin
-/bin/ln -fs ../../opt/CertNanny/bin/sscep_static $RPM_BUILD_ROOT/usr/bin/sscep
+/bin/ln -fs ../../opt/CertNanny/bin/sscep_dyn $RPM_BUILD_ROOT/usr/bin/sscep
 
 %clean 
 rm -rf $RPM_BUILD_ROOT 
@@ -40,7 +39,6 @@ rm -rf $RPM_BUILD_ROOT
 
 /opt/CertNanny/bin/sscep
 /opt/CertNanny/bin/sscep_dyn
-/opt/CertNanny/bin/sscep_static 
 /opt/CertNanny/COPYRIGHT.sscep
 /usr/bin/sscep
 

--- a/Linux/sscep-static.spec.in
+++ b/Linux/sscep-static.spec.in
@@ -1,0 +1,44 @@
+# 
+# SSCEP spec file 
+# 
+
+Name:         sscep-static 
+License:      GPL 
+Group:        Productivity/Security 
+Autoreqprov:  on 
+Summary:      Simple SCEP client
+Version:      VERSIONINFO
+Release:      1 
+Source:       %{name}-%{version}.tar.gz 
+URL:          https://github.com/certnanny/sscep
+BuildRoot:    %{_tmppath}/%{name}-build 
+
+%description 
+Simple SCEP (Simple Certificate Enrollment Protocol) client.
+
+%prep 
+%setup -n %{name}-%{version} 
+
+%build 
+make 
+
+%install 
+mkdir -p $RPM_BUILD_ROOT 
+install -D -m 755 sscep_static $RPM_BUILD_ROOT/opt/CertNanny/bin/sscep_static 
+install -D -m 644 COPYRIGHT $RPM_BUILD_ROOT/opt/CertNanny/COPYRIGHT.sscep
+/bin/ln -fs sscep_static $RPM_BUILD_ROOT/opt/CertNanny/bin/sscep 
+mkdir -p $RPM_BUILD_ROOT/usr/bin
+/bin/ln -fs ../../opt/CertNanny/bin/sscep_static $RPM_BUILD_ROOT/usr/bin/sscep
+
+%clean 
+rm -rf $RPM_BUILD_ROOT 
+
+%files 
+%defattr(-,root,root) 
+%doc README
+
+/opt/CertNanny/bin/sscep
+/opt/CertNanny/bin/sscep_static 
+/opt/CertNanny/COPYRIGHT.sscep
+/usr/bin/sscep
+


### PR DESCRIPTION
Because of RPM's behaviour of dynamically adding dependencies to RPM files based on dynamically linked applications in the package the we are now creating two separate versions, one with a statically linked sscep binary and one with the dynamically linked version.
