### PR TITLE
Issue 42: support issuer CAs other than a self-signed Root CA

### DIFF
--- a/sscep.c
+++ b/sscep.c
@@ -853,7 +853,7 @@ main(int argc, char **argv) {
 			}
 not_enroll:
 			if (!(scep_t.ias_getcertinit->issuer =
-					 X509_get_issuer_name(cacert))) {
+					 X509_get_subject_name(cacert))) {
 				fprintf(stderr, "%s: error getting issuer "
 					"for GetCertInitial\n", pname);
 				ERR_print_errors_fp(stderr);


### PR DESCRIPTION
This patch addresses the assumption that the SCEP protocol only works with an on-line Root CA and a maximum chain length of 2 (i.e. the on-line self-signed Root CA and the issued subordinate End Entity Certificates).

 Section 3.2.3 of SCEP draft contains a typo which results in the superior issuer rather than the issuing CA being identified to the SCEP responder within the GetCertInitial message. The RFC text should read:

" ….The issuer is set to the subjectName from the certification authority from which we issue certificates. The Subject is set to the SubjectName we used when generating the CSR and requesting the certificate……"

 Note: the significant change here is an issuing CA has a different SubjectDN and IssuerDN and we make sure these are correctly used. For an on-line Root CA SubjectDN and IssuerDN values are identical and the confusion doesn't matter.
