### PR TITLE
Added engine init commands support for dynamic engines

### DIFF
--- a/configuration.h
+++ b/configuration.h
@@ -51,6 +51,7 @@
 #define SCEP_CONFIGURATION_ENGINE_PKCS11_PIN			"PIN"
 #define SCEP_CONFIGURATION_ENGINE_DYNPATH				"dynamic_path"
 #define SCEP_CONFIGURATION_ENGINE_MODULEPATH			"MODULE_PATH"
+#define SCEP_CONFIGURATION_ENGINE_CMDS					"cmds"
 #define SCEP_CONFIGURATION_PARAM_CACERTFILE				"CACertFile"
 #define SCEP_CONFIGURATION_PARAM_NEXTCACERTFILE			"NextCACertFile"
 #define SCEP_CONFIGURATION_PARAM_CERTROOTCHAINFILE		"ChainRootCACertFile"
@@ -91,6 +92,11 @@ typedef struct {
 	char *engine_str;
 } SCEP_CONF;
 
+typedef struct {
+	char* name;
+	char* value;
+} NAME_VALUE_PAIR;
+
 struct scep_engine_conf_st{
 	char *engine_id; // ID of the engine according to OpenSSL (e.g. pkcs11, capi, chil, ...)
 	char *new_key_location; // CryptoAPI only option: Which storename to set for the new key, default: REQUEST
@@ -102,6 +108,7 @@ struct scep_engine_conf_st{
 	char *javapath; // Path to Java (JKSEngine)
 	char *pin; //the PIN used for the PKCS11 token, default: will be prompted (pkcs11)
 	char *module_path; // see OpenSSL ctrl MODULE_PATH for engines (example: PKCS#11)
+	NAME_VALUE_PAIR **cmds; // NULL terminated array of engine init commands (or NULL)
 };
 
 SCEP_CONF *scep_conf;

--- a/engine.c
+++ b/engine.c
@@ -153,6 +153,22 @@ ENGINE *scep_engine_load_dynamic(ENGINE *e) {
 	} else if(v_flag)
 		printf("%s: Loading engine %s succeeded\n", pname, g_char);
 
+	// Now issue any dynamic engine init cmds if any are configured
+	if(scep_conf->engine->cmds != NULL) {
+        int i=0;
+        while(scep_conf->engine->cmds[i] != NULL) {
+                 NAME_VALUE_PAIR *cmd = scep_conf->engine->cmds[i];
+                 if(ENGINE_ctrl_cmd_string(e, cmd->name, cmd->value, 0) == 0) {
+                         fprintf(stderr, "%s: Executing %s=%s failed\n", pname, cmd->name, cmd->value);
+                         sscep_engine_report_error();
+                         exit (SCEP_PKISTATUS_ERROR);
+                 } else if(v_flag) {
+                         fprintf(stderr, "%s: Engine command %s=%s succeeded\n", pname, cmd->name, cmd->value);
+                 }
+                 i++;
+         }
+	}
+
 	//all these functions were only needed if we loaded dynamically. Otherwise we could just skip this step.
 
 	return e;


### PR DESCRIPTION
I needed support for initializing a custom OpenSSL engine with some init commands. This patch adds support for that in a separate commands section in the config file.