### PR TITLE
Linux makefile fix and cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+cmake_minimum_required(VERSION 2.8.11)
+project(SSCEP)
+
+add_executable (${PROJECT_NAME} sscep.c init.c net.c sceputils.c pkcs7.c ias.c fileutils.c configuration.c engine.c)
+
+target_link_libraries (${PROJECT_NAME} ssl crypto)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION bin)
+
+
+SET(CPACK_PACKAGE_CONTACT "Scott T. Hardin")
+
+INCLUDE(CPack)

--- a/Linux/Makefile
+++ b/Linux/Makefile
@@ -11,19 +11,19 @@ OPENSSL = ../openssl
 CFLAGS	= -Wall -O $(WITH_DEBUG) -I $(OPENSSL)/include 
 
 LDFLAGS = -L$(OPENSSL)
-LDLIBS = -lcrypto
+LDLIBS = -lcrypto -lssl
 
 MAN	= sscep.8
 PROG	= sscep
 OBJS    = sscep.o init.o net.o sceputils.o pkcs7.o ias.o fileutils.o configuration.o engine.o
 
-all: $(PROG)_static $(PROG)_dyn
+all: $(PROG)_dyn
 
 $(PROG)_static: $(OBJS)
 	$(CC) $(CFLAGS) -o $(PROG)_static $(OBJS) $(OPENSSL)/libcrypto.a -ldl
 
 $(PROG)_dyn: $(OBJS)
-	$(CC) $(CFLAGS) -o $(PROG)_dyn $(OBJS) $(LDLIBS) $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $(PROG)_dyn $(OBJS) $(LDLIBS)
 
 clean:
 	rm -f $(PROG) $(OBJS) $(MAN) core
@@ -34,4 +34,3 @@ install:
 package: all
 	echo "Creating package..."
 	Linux/make_Linux_package.sh
-


### PR DESCRIPTION
- The Linux Makefile appears to be broken. Fixed it by removing statically linked binary and linking against ssl.
- How about adding cmake support? That would address many things that were previously addressed through scripts (ex: Configure script, package building). Added CMakeList.txt. Resulting binary appears to be running properly.