### PR TITLE
Older openssl fix

### DIFF
--- a/pkcs7.c
+++ b/pkcs7.c
@@ -864,7 +864,15 @@ int get_signed_attribute(STACK_OF(X509_ATTRIBUTE) *attribs, int nid,int type, ch
 			pname);	
 		exit (SCEP_PKISTATUS_P7);
 	}
+/* for compatibility with older openssl versions
+   from: https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes
+
+*/
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+	memcpy(*buffer, ASN1_STRING_data(asn1_type->value.asn1_string), len);
+#else
 	memcpy(*buffer, ASN1_STRING_get0_data(asn1_type->value.asn1_string), len);
+#endif
 
 	/* Add null terminator if it's a PrintableString */
 	if (type == V_ASN1_PRINTABLESTRING) {

--- a/sscep.h
+++ b/sscep.h
@@ -65,7 +65,7 @@
 #include <openssl/ssl.h>
 /* Global defines */
 
-#define	VERSION	"0.7"
+#define	VERSION	"0.6.1"
 
 /* SCEP operations */
 int operation_flag;


### PR DESCRIPTION
Allow sscep to be compiled with OpenSSL < 1.1.0.
Done according to OpenSSL's documentation: https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes