### PR TITLE
Added Docker version and link to Dockerfile repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sscep-docker"]
+	path = sscep-docker
+	url = https://github.com/pertoft/sscep-docker

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ SSCEP has been tested successfully against the following CA products:
 > (\*\*\*\*) automatic approval according to newer SCEP drafts requires
        OpenCA 0.9.2.4 or higher
 
+
+## Docker version
+Run a single command using:
+`docker run -it pertoft/sscep-docker:latest sscep getca -c tmp/cacert -u http://yourhost/scep/scep`
+
+or alternative to get an interactive shell:
+
+`docker run -it pertoft/sscep-docker:latest bash`
+
+Alternative you can jump into the container and run scep commands docker run -it pertoft/sscep-docker:latest bash
+
+
 ## HOW TO COMPILE
 
 The program should compile on the following systems:


### PR DESCRIPTION
I have created a docker image of the sscep software on Docker Hub, which makes it easy to run the sscep without compilation.
https://hub.docker.com/r/pertoft/sscep-docker
