### PR TITLE
Fix GetCRL/GetCert for situations where RA and CA certifificate differ

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,12 +198,15 @@ OPTIONS for OPERATION enroll are
 OPTIONS for OPERATION getcert are
   -k <file>         Signature private key file
   -l <file>         Signature local certificate file
+  -O <file>         Issuer Certificate of the certificate to query (requires -s)
   -s <number>       Certificate serial number (decimal)
   -w <file>         Write certificate in file
 
 OPTIONS for OPERATION getcrl are
   -k <file>         Signature private key file
   -l <file>         Signature local certificate file
+  -O <file>         Certificate to get the CRL for (reads issuer and serial)
+  -s <number>       Certificate serial number (decimal)
   -w <file>         Write CRL in file
 ```
 
@@ -236,7 +239,7 @@ Here are the available configuration file keys and example values:
 | URL | URL of the SCEP server. | `http://example.com/scep` | `-u` |
 | CACertFile | Sigle CA certificate file, or mutiple CA certificates suffixed with `-0`, `-1`, ... to write (getca) or to choose from (all other operations). | `./ca.crt` |`-c` |
 | CAIdentifier | Some CAs require you to define this.  | `mydomain.com` | `-i` |
-| CertReqFile | Certificate request file created with mkrequest. | `./local.csr` | `-r`
+| CertReqFile | Certificate request file created with mkrequest. | `./local.csr` | `-r` |
 | EncAlgorithm | PKCS#7 encryption algorithm. Available algorithms are des, 3des, blowfish, aes/aes128, aes192 and aes256. NOTE: SCEP provides no mechanism to "negotiate" the algorithm - even if you send 3des, reply might be des (same thing applies to SigAlgorithm). | | `-E` |
 | EncCertFile | If your CA/RA uses a different certificate for encyption and signing, define this. CACertFile is used for verifying the signature. | `./enc.crt` | `-e` |
 | SignCertFile | Instead of creating a self-signed certificate from the new key pair use an already existing certficate/key to sign the SCEP request. If the "old" certificate and key is used, the CA can verify that the holder of the private key for an existing certificate re-enrolls for a renewal certificate, allowing for automatic approval of the request. Requires specification of the corresponding SignKeyFile (`-K`). | `./sig.crt` | `-O` |

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -458,7 +458,13 @@ int scep_conf_load_operation_getcert(CONF *conf) {
 		if(!(w_char = strdup(var)))
 			error_memory();
 	}
-	
+
+	if((var = NCONF_get_string(conf, SCEP_CONFIGURATION_SECTION_ENROLL, SCEP_CONFIGURATION_PARAM_SIGNCERTFILE)) && !O_flag) {
+		O_flag = 1;
+		if(!(O_char = strdup(var)))
+			error_memory();
+	}
+
 	return 0;
 }
 
@@ -476,9 +482,21 @@ int scep_conf_load_operation_getcrl(CONF *conf) {
 			error_memory();
 	}
 
+	if((var = NCONF_get_string(conf, SCEP_CONFIGURATION_SECTION_GETCERT, SCEP_CONFIGURATION_PARAM_GETCERTSERIAL)) && !s_flag) {
+		s_flag = 1;
+		if(!(s_char = strdup(var)))
+			error_memory();
+	}
+
 	if((var = NCONF_get_string(conf, SCEP_CONFIGURATION_SECTION_GETCRL, SCEP_CONFIGURATION_PARAM_GETCRLFILE)) && !w_flag) {
 		w_flag = 1;
 		if(!(w_char = strdup(var)))
+			error_memory();
+	}
+
+	if((var = NCONF_get_string(conf, SCEP_CONFIGURATION_SECTION_ENROLL, SCEP_CONFIGURATION_PARAM_SIGNCERTFILE)) && !O_flag) {
+		O_flag = 1;
+		if(!(O_char = strdup(var)))
 			error_memory();
 	}
 
@@ -506,14 +524,14 @@ void scep_dump_conf() {
 		"-c / CACertFile",
 		"-i / CAIdentifier",
 		"-r / CertReqFile",
-		"-d / Debug", 
+		"-d / Debug",
 		"-e / EncCertFile",
-		"-E / EncAlgorithm", 
+		"-E / EncAlgorithm",
 		"-F / FingerPrint",
-		"-w / GetCertFile od. GetCrlFile",
+		"-w / GetCertFile or GetCrlFile",
 		"-s / GetCertSerial",
 		"-l / LocalCertFile",
-		"-O / SignCertFile",
+		"-O / SignCertFile or IssuerCertFile",
 		"-n / MaxPollCount",
 		"-T / MaxPollTime",
 		"-k / PrivateKeyFile",
@@ -526,7 +544,7 @@ void scep_dump_conf() {
 		"-v / Verbose",
 		"-R / Resume"
 	};
-	
+
 	T_char = (char *) malloc(sizeof(char) * 20);
 	n_char = (char *) malloc(sizeof(char) * 20);
 	t_char = (char *) malloc(sizeof(char) * 20);

--- a/src/pkcs7.c
+++ b/src/pkcs7.c
@@ -167,7 +167,7 @@ int pkcs7_wrap(struct scep *s, int enc_base64) {
 			if ((rc = i2d_PKCS7_ISSUER_AND_SERIAL_bio(databio,
 						s->ias_getcrl)) <= 0) {
 				fprintf(stderr, "%s: error writing "
-					"GetCert data in bio\n", pname);
+					"GetCRL data in bio\n", pname);
 				ERR_print_errors_fp(stderr);
 				exit (SCEP_PKISTATUS_P7);
 			}


### PR DESCRIPTION
The GetCRL/GetCert commands send an issuer-serial to identify the
requested ressource. This information is read from the RA certificate
which will return unusable information when the SCEP RA certificate
is not the CA itself. This is a common situation when running SCEP
on a "real" CA and not in an embded setup.

This patch introduces the "-O" and "-s" flags to pass a different
certificate to read the required name and serial from.