### PR TITLE
auto-select using wrong encryption certificate

### DIFF
--- a/src/pkcs7.c
+++ b/src/pkcs7.c
@@ -202,8 +202,12 @@ int pkcs7_wrap(struct scep *s, int enc_base64) {
 		ERR_print_errors_fp(stderr);
 		exit (SCEP_PKISTATUS_P7);
 	}
-	/* Use different CA cert for encryption if requested */
-	if (e_flag) {
+	/*
+	 * Use different CA cert for encryption if requested.
+	 * encert will be non-NULL if the -e option was specified on the command
+	 * line, or if the certificates were auto-selected.
+	 */
+	if (encert != NULL) {
 		if (sk_X509_push(recipients, encert) <= 0) {
 			fprintf(stderr, "%s: error adding recipient encryption "
 					"certificate\n", pname);


### PR DESCRIPTION
When not using the '-e' command line option to specify the encryption
certificate the auto-selected certificate wasn't being used during an
enrollment request, which resulted in failed requests.
If auto-selecting and the encert differed from the cacert it was
incorrectly using the cacert certificate.
When the '-e' option is used then encert will always be non-null, and
when auto-selecting the encert it will also be non-null. encert will
only be null if the '-e' flag is not used and the '-c' flag points to a
valid certificate (so no auto-selecting).
Fixed the problem by using encert if it is non-NULL, else using cacert.