### PR TITLE
Improve auto-select of certificates

### DIFF
--- a/src/sscep.h
+++ b/src/sscep.h
@@ -179,6 +179,7 @@ extern X509 *cacert;
 extern X509 *encert;
 extern X509 *localcert;
 extern X509 *renewal_cert;
+extern X509 *issuer_cert;
 extern X509_REQ *request;
 extern EVP_PKEY *rsa;
 extern EVP_PKEY *renewal_key;
@@ -317,7 +318,8 @@ EVP_PKEY *read_key(char* filename);
 void read_key_Engine(EVP_PKEY** key, char* filename, ENGINE *e);
 
 /* Read CA certificate file */
-void guess_ca_certs(const char* filename, X509 **vercert, X509 **encert);
+void guess_ca_certs(const char* filename, X509_NAME *issuer_name,
+					X509 **vercert, X509 **encert, X509 **issuer_cert);
 
 /* Read local certificate file */
 X509 *read_cert(const char* filename);


### PR DESCRIPTION
This change resolves a problem we were having where we were trying to use auto-selection of certificates with getCRL operations, but the client was incorrectly using details from the signing certificate rather than the expected issuer certificate.

Note that thought that these changes might also apply to getCERT operations, but I wasn't sure and have no way of testing those changes. For that reason I have specifically made them apply to getCRL operations only.

If performing a GETCRL request and auto-selecting certificates, guess
at the issuer certificate by using the certificate that has the same
subject name as the issuer of the local certificate (specified with
'-l').
Previously, auto-selection would use the auto-selected 'cacert', which
would most likely _not_ be the issuing certificate of the local
certificate.

This may still be overridden by using the -O command line option to
specify the issuer certificate.
