### PR TITLE
Fix hostname parsing when using proxy

### DIFF
--- a/src/sscep.c
+++ b/src/sscep.c
@@ -612,7 +612,7 @@ main(int argc, char **argv) {
 				p++;
 			}
 		} else {
-			if (!cnt && !c) {
+			if (!cnt && !p_flag && !c) {
 				dir_name = p;
 				cnt = 1;
 			}


### PR DESCRIPTION
"Proper" fix of the bug when using proxy.

Issue and original pull request is described here: https://github.com/certnanny/sscep/pull/143