### PR TITLE
Fix getopt linking error

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -31,6 +31,16 @@
 #include <stddef.h>
 #include <string.h>
 
+#define GETOPT_INTERFACE_VERSION 2
+#if !defined _LIBC && defined __GLIBC__ && __GLIBC__ >= 2
+# include <gnu-versions.h>
+# if _GNU_GETOPT_INTERFACE_VERSION == GETOPT_INTERFACE_VERSION
+#  define ELIDE_CODE
+# endif
+#endif
+
+#ifndef ELIDE_CODE
+
 char* optarg;
 int optopt;
 /* The variable optind [...] shall be initialized to 1 by the system. */
@@ -226,3 +236,5 @@ int getopt_long(int argc, char* const argv[], const char* optstring,
   ++optind;
   return retval;
 }
+
+#endif	/* Not ELIDE_CODE.  */


### PR DESCRIPTION
The buildroot project, to which the sscep application was added, has configurations that raise the following linking error: buildroot/output/host/lib/gcc/arc-buildroot-linux-uclibc/11.3.0/../../../../arc-buildroot-linux-uclibc/bin/ld: buildroot/output/host/bin/../arc-buildroot-linux-uclibc/sysroot/usr/lib/libc.a(getopt.os):(.data+0x8): multiple definition of `optind'; src/getopt.o:(.data+0x0): first defined here buildroot/output/host/lib/gcc/arc-buildroot-linux-uclibc/11.3.0/../../../../arc-buildroot-linux-uclibc/bin/ld: buildroot/output/host/bin/../arc-buildroot-linux-uclibc/sysroot/usr/lib/libc.a(getopt.os): in function `__GI_getopt': getopt.c:(.text+0x5a4): multiple definition of `getopt'; src/getopt.o:getopt.c:(.text+0x0): first defined here buildroot/output/host/lib/gcc/arc-buildroot-linux-uclibc/11.3.0/../../../../arc-buildroot-linux-uclibc/bin/ld: buildroot/output/host/bin/../arc-buildroot-linux-uclibc/sysroot/usr/lib/libc.a(getopt.os): in function `getopt_long': getopt.c:(.text+0x5b0): multiple definition of `getopt_long'; src/getopt.o:getopt.c:(.text+0x128): first defined here collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:507: sscep] Error 1
make[1]: *** [package/pkg-generic.mk:293: buildroot/output/build/sscep-0.10.0/.stamp_built] Error 2

The patch re-added a check that commit
81f56f635259b9 ("Replaced GNU getopt by a BSD licensed alternative") removed.

Signed-off-by: Dario Binacchi <dario.binacchi@amarulasolutions.com>