### PR TITLE
Close #62 #149: pass a private key passphrase to an enroll request

### DIFF
--- a/src/engine.c
+++ b/src/engine.c
@@ -179,7 +179,7 @@ ENGINE *scep_engine_load_dynamic(void) {
 
 //idea from: http://blog.burghardt.pl/2010/03/ncipher-hsm-with-openssl/
 void sscep_engine_read_key(EVP_PKEY **key, char *id, ENGINE *e) {
-	*key = ENGINE_load_private_key(e, id, NULL, NULL);
+	*key = ENGINE_load_private_key(e, id, UI_get_default_method(), NULL);
 	//ERR_print_errors_fp(stderr);
 
 	if(*key == 0) {


### PR DESCRIPTION
Implement the Openssl syntax according to:
https://www.openssl.org/docs/man3.0/man1/openssl-passphrase-options.html

Enable this feature (and keyboard login) for ENGINE keys.

Removing the passphrase from a software key is sometimes possible, but removing it from from an ENGINE key is usually impossible.

The OS will drop the allocated memory for the UI_METHOD. This is a short running app after all.