### PR TITLE
Fix getopt linking error with musl-libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,7 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([alarm gethostbyname memset socket strchr strdup strstr])
+AC_CHECK_FUNCS([alarm gethostbyname getopt memset socket strchr strdup strstr])
 
 AC_CONFIG_FILES([Makefile])
 AC_SUBST([LIBTOOL_DEPS])

--- a/src/getopt.c
+++ b/src/getopt.c
@@ -31,15 +31,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#define GETOPT_INTERFACE_VERSION 2
-#if !defined _LIBC && defined __GLIBC__ && __GLIBC__ >= 2
-# include <gnu-versions.h>
-# if _GNU_GETOPT_INTERFACE_VERSION == GETOPT_INTERFACE_VERSION
-#  define ELIDE_CODE
-# endif
-#endif
-
-#ifndef ELIDE_CODE
+#ifndef HAVE_GETOPT
 
 char* optarg;
 int optopt;
@@ -237,4 +229,4 @@ int getopt_long(int argc, char* const argv[], const char* optstring,
   return retval;
 }
 
-#endif	/* Not ELIDE_CODE.  */
+#endif	/* HAVE_GETOPT  */


### PR DESCRIPTION
The patch, by modifying configure.ac, attempts to solve the linking issue with getopt for every possible use case.